### PR TITLE
chore(scrutinizer): exclude tests directory

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,2 +1,6 @@
+filter:
+    excluded_paths:
+        - tests/
+
 tools:
     external_code_coverage: true


### PR DESCRIPTION
# Description

Update scrutinizer configuration to exclude `tests/` directory from inspections

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | no
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | ~
| License        | MIT
