### PR TITLE
fix(node): endpoints

### DIFF
--- a/src/Node/Cluster.php
+++ b/src/Node/Cluster.php
@@ -45,12 +45,13 @@ class Cluster extends AbstractNode
     /**
      * forcibly remove a node
      *
+     * @param string $name
      * @param \Unikorp\KongAdminApi\Document\Cluster $document
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function forciblyRemoveANode(Document $document): ResponseInterface
+    public function forciblyRemoveANode(string $name, Document $document): ResponseInterface
     {
-        return $this->delete('/cluster', $document);
+        return $this->delete(sprintf('/cluster/nodes/%1$s', $name), $document);
     }
 }

--- a/src/Node/Cluster.php
+++ b/src/Node/Cluster.php
@@ -39,7 +39,7 @@ class Cluster extends AbstractNode
      */
     public function retrieveClusterStatus(): ResponseInterface
     {
-        return $this->get('/cluster/nodes');
+        return $this->get('/cluster/nodes/');
     }
 
     /**

--- a/tests/Node/ClusterTest.php
+++ b/tests/Node/ClusterTest.php
@@ -167,13 +167,13 @@ class ClusterTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/cluster'),
+                $this->equalTo('/cluster/nodes/test-cluster'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->forciblyRemoveANode($document);
+        $node->forciblyRemoveANode('test-cluster', $document);
     }
 }

--- a/tests/Node/ClusterTest.php
+++ b/tests/Node/ClusterTest.php
@@ -130,7 +130,7 @@ class ClusterTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/cluster/nodes'))
+            ->with($this->equalTo('/cluster/nodes/'))
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);


### PR DESCRIPTION
# Description

Fix missing trailing slash in `retrieveClusterStatus` endpoint
Fix wrong `forciblyRemoveANode` endpoint 

# Breaking change

`Node\Cluster::forciblyRemoveANode(Document $document): ResponseInterface` -> `Node\Cluster::forciblyRemoveANode(string $name, Document $document): ResponseInterface`

---

| Q              | A
| -------------- | ---
| Bug fix ?      | yes
| New feature ?  | no
| BC breaks ?    | yes
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | [fixes #10, fixes #11]
| License        | MIT
