### PR TITLE
fix(node): wrong endpoints in cluster node

### DIFF
--- a/src/Node/Cluster.php
+++ b/src/Node/Cluster.php
@@ -23,35 +23,36 @@ use Unikorp\KongAdminApi\Document\Cluster as Document;
 class Cluster extends AbstractNode
 {
     /**
-     * cluster information
-     *
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    public function clusterInformation(): ResponseInterface
-    {
-        return $this->get('/cluster');
-    }
-
-    /**
      * retrieve cluster status
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function retrieveClusterStatus(): ResponseInterface
     {
-        return $this->get('/cluster/nodes/');
+        return $this->get('/cluster');
+    }
+
+    /**
+     * add a node
+     *
+     * @param \Unikorp\KongAdminApi\Document\Cluster $document
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function addANode(Document $document): ResponseInterface
+    {
+        return $this->post('/cluster', $document);
     }
 
     /**
      * forcibly remove a node
      *
-     * @param string $name
      * @param \Unikorp\KongAdminApi\Document\Cluster $document
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function forciblyRemoveANode(string $name, Document $document): ResponseInterface
+    public function forciblyRemoveANode(Document $document): ResponseInterface
     {
-        return $this->delete(sprintf('/cluster/nodes/%1$s', $name), $document);
+        return $this->delete('/cluster', $document);
     }
 }

--- a/tests/Unit/Node/ClusterTest.php
+++ b/tests/Unit/Node/ClusterTest.php
@@ -82,34 +82,6 @@ class ClusterTest extends TestCase
     }
 
     /**
-     * test cluster information
-     *
-     * @return void
-     *
-     * @covers \Unikorp\KongAdminApi\Node\Cluster::clusterInformation
-     * @covers \Unikorp\KongAdminApi\AbstractNode::get
-     */
-    public function testClusterInformation()
-    {
-        // stub `get http client` method from `client` mock
-        $this->client->expects($this->once())
-            ->method('getHttpClient')
-            ->will($this->returnValue($this->httpClient));
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
-        // stub `get` method from `http client` mock
-        $this->httpClient->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('/cluster'))
-            ->will($this->returnValue($response));
-
-        $node = new Node($this->client);
-        $node->clusterInformation();
-    }
-
-    /**
      * test retrieve cluster status
      *
      * @return void
@@ -130,11 +102,51 @@ class ClusterTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/cluster/nodes/'))
+            ->with($this->equalTo('/cluster'))
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
         $node->retrieveClusterStatus();
+    }
+
+    /**
+     * test add a node
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Node\Cluster::addANode
+     * @covers \Unikorp\KongAdminApi\AbstractNode::post
+     */
+    public function testAddANode()
+    {
+        // stub `get http client` method from `client` mock
+        $this->client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($this->httpClient));
+
+        // mock `document`
+        $document = $this->createMock('\Unikorp\KongAdminApi\Document\Cluster');
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // stub `to json` method from `document` mock
+        $document->expects($this->once())
+            ->method('toJson')
+            ->will($this->returnValue('{"test":true}'));
+
+        // stub `delete` method from `http client` mock
+        $this->httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('/cluster'),
+                $this->equalTo(['Content-Type' => 'application/json']),
+                $this->equalTo('{"test":true}')
+            )
+            ->will($this->returnValue($response));
+
+        $node = new Node($this->client);
+        $node->addANode($document);
     }
 
     /**
@@ -167,13 +179,13 @@ class ClusterTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/cluster/nodes/test-cluster'),
+                $this->equalTo('/cluster'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->forciblyRemoveANode('test-cluster', $document);
+        $node->forciblyRemoveANode($document);
     }
 }


### PR DESCRIPTION
# Description

fix wrong endpoints in Cluster Node

# Breaking changes

`Node\Cluster::forciblyRemoveANode(string $name, Document $document): ResponseInterface` -> `Node\Cluster::forciblyRemoveANode(Document $document): ResponseInterface`

---

| Q              | A
| -------------- | ---
| Bug fix ?      | yes
| New feature ?  | no
| BC breaks ?    | yes
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | fixes #20
| License        | MIT
