### PR TITLE
fix(document): missing property in cluster document

### DIFF
--- a/src/Document/Cluster.php
+++ b/src/Document/Cluster.php
@@ -27,6 +27,12 @@ class Cluster extends AbstractDocument
     protected $name = null;
 
     /**
+     * address
+     * @var string $address
+     */
+    protected $address = null;
+
+    /**
      * set name
      *
      * @param string $name
@@ -51,6 +57,30 @@ class Cluster extends AbstractDocument
     }
 
     /**
+     * set address
+     *
+     * @param string $address
+     *
+     * @return this
+     */
+    public function setAddress(string $address): self
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    /**
+     * get address
+     *
+     * @return string
+     */
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    /**
      * get fields
      *
      * @return array
@@ -59,6 +89,7 @@ class Cluster extends AbstractDocument
     {
         return [
             'name',
+            'address',
         ];
     }
 }

--- a/tests/Unit/Document/ClusterTest.php
+++ b/tests/Unit/Document/ClusterTest.php
@@ -87,6 +87,41 @@ class ClusterTest extends TestCase
     }
 
     /**
+     * test set address
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Document\Cluster::setAddress
+     */
+    public function testSetAddress()
+    {
+        // asserts
+        $this->document->setAddress('test');
+        $this->assertSame('test', $this->readAttribute($this->document, 'address'));
+    }
+
+    /**
+     * test get address
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Document\Cluster::getAddress
+     */
+    public function testGetAddress()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `address` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('address');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'test');
+        $this->assertSame('test', $this->document->getAddress());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -98,8 +133,9 @@ class ClusterTest extends TestCase
     public function testToJson()
     {
         $this->document
-            ->setName('name');
+            ->setName('name')
+            ->setAddress('address');
 
-        $this->assertSame('{"name":"name"}', $this->document->toJson());
+        $this->assertSame('{"name":"name","address":"address"}', $this->document->toJson());
     }
 }


### PR DESCRIPTION
# Description

fix missing property `address` in Cluster Document

---

| Q              | A
| -------------- | ---
| Bug fix ?      | yes
| New feature ?  | no
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | fixes #22
| License        | MIT
