### PR TITLE
feat(document): handle created at field

### DIFF
--- a/src/AbstractDocument.php
+++ b/src/AbstractDocument.php
@@ -19,11 +19,47 @@ namespace Unikorp\KongAdminApi;
 abstract class AbstractDocument implements DocumentInterface
 {
     /**
+     * default fields
+     * @const array DEFAULT_FIELDS
+     */
+    const DEFAULT_FIELDS = ['createdAt'];
+
+    /**
+     * created at
+     * @param int $createdAt
+     */
+    protected $createdAt = null;
+
+    /**
      * get fields
      *
      * @return array
      */
     abstract protected function getFields(): array;
+
+    /**
+     * set created at
+     *
+     * @param int $createdAt
+     *
+     * @return this
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * get created at
+     *
+     * @return int
+     */
+    public function getCreatedAt(): int
+    {
+        return $this->createdAt;
+    }
 
     /**
      * to json
@@ -34,7 +70,7 @@ abstract class AbstractDocument implements DocumentInterface
     {
         $document = [];
 
-        foreach ($this->getFields() as $field) {
+        foreach (array_merge($this->getFields(), self::DEFAULT_FIELDS) as $field) {
             if (!is_null($value = $this->$field)) {
                 $document[$this->toSnakeCase($field)] = $value;
             }

--- a/src/AbstractNode.php
+++ b/src/AbstractNode.php
@@ -81,6 +81,8 @@ abstract class AbstractNode implements NodeInterface
      */
     protected function put($endpoint, DocumentInterface $document = null)
     {
+        $document->setCreatedAt(time());
+
         return $this->client->getHttpClient()->put(
             $endpoint,
             self::JSON_CONTENT_TYPE,

--- a/src/Document/Plugin.php
+++ b/src/Document/Plugin.php
@@ -156,7 +156,7 @@ class Plugin extends AbstractDocument
     {
         $document = [];
 
-        foreach ($this->getFields() as $field) {
+        foreach (array_merge($this->getFields(), self::DEFAULT_FIELDS) as $field) {
             if (!is_null($value = $this->$field)) {
                 if (is_array($value)) {
                     foreach (array_keys($value) as $key) {

--- a/tests/Unit/Document/ApiTest.php
+++ b/tests/Unit/Document/ApiTest.php
@@ -507,6 +507,41 @@ class ApiTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -530,10 +565,11 @@ class ApiTest extends TestCase
             ->setUpstreamSendTimeout(10000)
             ->setUpstreamReadTimeout(10000)
             ->setHttpsOnly(true)
-            ->setHttpIfTerminated(false);
+            ->setHttpIfTerminated(false)
+            ->setCreatedAt(42);
 
         $this->assertSame(
-            '{"name":"name","hosts":"hosts","uris":"uris","methods":"methods","upstream_url":"upstreamUrl","strip_uri":false,"preserve_host":true,"retries":10,"upstream_connect_timeout":10000,"upstream_send_timeout":10000,"upstream_read_timeout":10000,"https_only":true,"http_if_terminated":false}',
+            '{"name":"name","hosts":"hosts","uris":"uris","methods":"methods","upstream_url":"upstreamUrl","strip_uri":false,"preserve_host":true,"retries":10,"upstream_connect_timeout":10000,"upstream_send_timeout":10000,"upstream_read_timeout":10000,"https_only":true,"http_if_terminated":false,"created_at":42}',
             $this->document->toJson()
         );
     }

--- a/tests/Unit/Document/CertificateTest.php
+++ b/tests/Unit/Document/CertificateTest.php
@@ -157,6 +157,41 @@ class CertificateTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -170,10 +205,11 @@ class CertificateTest extends TestCase
         $this->document
             ->setCert('cert')
             ->setKey('key')
-            ->setSnis('snis');
+            ->setSnis('snis')
+            ->setCreatedAt(42);
 
         $this->assertSame(
-            '{"cert":"cert","key":"key","snis":"snis"}',
+            '{"cert":"cert","key":"key","snis":"snis","created_at":42}',
             $this->document->toJson()
         );
     }

--- a/tests/Unit/Document/ClusterTest.php
+++ b/tests/Unit/Document/ClusterTest.php
@@ -122,6 +122,41 @@ class ClusterTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -134,8 +169,9 @@ class ClusterTest extends TestCase
     {
         $this->document
             ->setName('name')
-            ->setAddress('address');
+            ->setAddress('address')
+            ->setCreatedAt(42);
 
-        $this->assertSame('{"name":"name","address":"address"}', $this->document->toJson());
+        $this->assertSame('{"name":"name","address":"address","created_at":42}', $this->document->toJson());
     }
 }

--- a/tests/Unit/Document/ConsumerTest.php
+++ b/tests/Unit/Document/ConsumerTest.php
@@ -129,6 +129,41 @@ class ConsumerTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -141,8 +176,9 @@ class ConsumerTest extends TestCase
     {
         $this->document
             ->setUsername('username')
-            ->setCustomId('customId');
+            ->setCustomId('customId')
+            ->setCreatedAt(42);
 
-        $this->assertSame('{"username":"username","custom_id":"customId"}', $this->document->toJson());
+        $this->assertSame('{"username":"username","custom_id":"customId","created_at":42}', $this->document->toJson());
     }
 }

--- a/tests/Unit/Document/InformationTest.php
+++ b/tests/Unit/Document/InformationTest.php
@@ -52,6 +52,41 @@ class InformationTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -61,6 +96,8 @@ class InformationTest extends TestCase
      */
     public function testToJson()
     {
-        $this->assertSame('[]', $this->document->toJson());
+        $this->document->setCreatedAt(42);
+
+        $this->assertSame('{"created_at":42}', $this->document->toJson());
     }
 }

--- a/tests/Unit/Document/PluginTest.php
+++ b/tests/Unit/Document/PluginTest.php
@@ -207,6 +207,41 @@ class PluginTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -221,10 +256,11 @@ class PluginTest extends TestCase
             ->setName('name')
             ->setConsumerId('consumerId')
             ->addConfig('test', true)
-            ->addConfig('something_else', 'something_else');
+            ->addConfig('something_else', 'something_else')
+            ->setCreatedAt(42);
 
         $this->assertSame(
-            '{"name":"name","consumer_id":"consumerId","config.test":true,"config.something_else":"something_else"}',
+            '{"name":"name","consumer_id":"consumerId","config.test":true,"config.something_else":"something_else","created_at":42}',
             $this->document->toJson()
         );
     }

--- a/tests/Unit/Document/SniTest.php
+++ b/tests/Unit/Document/SniTest.php
@@ -122,6 +122,41 @@ class SniTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -134,10 +169,11 @@ class SniTest extends TestCase
     {
         $this->document
             ->setName('name')
-            ->setSslCertificateId('sslCertificateId');
+            ->setSslCertificateId('sslCertificateId')
+            ->setCreatedAt(42);
 
         $this->assertSame(
-            '{"name":"name","ssl_certificate_id":"sslCertificateId"}',
+            '{"name":"name","ssl_certificate_id":"sslCertificateId","created_at":42}',
             $this->document->toJson()
         );
     }

--- a/tests/Unit/Document/TargetTest.php
+++ b/tests/Unit/Document/TargetTest.php
@@ -122,6 +122,41 @@ class TargetTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -134,10 +169,11 @@ class TargetTest extends TestCase
     {
         $this->document
             ->setTarget('target')
-            ->setWeight(1000);
+            ->setWeight(1000)
+            ->setCreatedAt(42);
 
         $this->assertSame(
-            '{"target":"target","weight":1000}',
+            '{"target":"target","weight":1000,"created_at":42}',
             $this->document->toJson()
         );
     }

--- a/tests/Unit/Document/UpstreamTest.php
+++ b/tests/Unit/Document/UpstreamTest.php
@@ -157,6 +157,41 @@ class UpstreamTest extends TestCase
     }
 
     /**
+     * test set created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setCreatedAt
+     */
+    public function testSetCreatedAt()
+    {
+        // asserts
+        $this->document->setCreatedAt(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'createdAt'));
+    }
+
+    /**
+     * test get created at
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getCreatedAt
+     */
+    public function testGetCreatedAt()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `created at` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('createdAt');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getCreatedAt());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -170,10 +205,11 @@ class UpstreamTest extends TestCase
         $this->document
             ->setName('name')
             ->setSlots(65536)
-            ->setOrderlist([1, 2, 7, 9, 6, 3]);
+            ->setOrderlist([1, 2, 7, 9, 6, 3])
+            ->setCreatedAt(42);
 
         $this->assertSame(
-            '{"name":"name","slots":65536,"orderlist":[1,2,7,9,6,3]}',
+            '{"name":"name","slots":65536,"orderlist":[1,2,7,9,6,3],"created_at":42}',
             $this->document->toJson()
         );
     }

--- a/tests/Unit/Node/ApiTest.php
+++ b/tests/Unit/Node/ApiTest.php
@@ -238,6 +238,11 @@ class ApiTest extends TestCase
         // mock `document`
         $document = $this->createMock('\Unikorp\KongAdminApi\Document\Api');
 
+        // stub `set created at` method from `document` mock
+        $document->expects($this->once())
+            ->method('setCreatedAt')
+            ->with($this->isType('int'));
+
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')

--- a/tests/Unit/Node/CertificateTest.php
+++ b/tests/Unit/Node/CertificateTest.php
@@ -238,6 +238,11 @@ class CertificateTest extends TestCase
         // mock `document`
         $document = $this->createMock('\Unikorp\KongAdminApi\Document\Certificate');
 
+        // stub `set created at` method from `document` mock
+        $document->expects($this->once())
+            ->method('setCreatedAt')
+            ->with($this->isType('int'));
+
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')

--- a/tests/Unit/Node/ConsumerTest.php
+++ b/tests/Unit/Node/ConsumerTest.php
@@ -238,6 +238,11 @@ class ConsumerTest extends TestCase
         // mock `response`
         $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
+        // stub `set created at` method from `document` mock
+        $document->expects($this->once())
+            ->method('setCreatedAt')
+            ->with($this->isType('int'));
+
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')

--- a/tests/Unit/Node/PluginTest.php
+++ b/tests/Unit/Node/PluginTest.php
@@ -266,6 +266,11 @@ class PluginTest extends TestCase
         // mock `response`
         $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
+        // stub `set created at` method from `document` mock
+        $document->expects($this->once())
+            ->method('setCreatedAt')
+            ->with($this->isType('int'));
+
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')

--- a/tests/Unit/Node/SniTest.php
+++ b/tests/Unit/Node/SniTest.php
@@ -238,6 +238,11 @@ class SniTest extends TestCase
         // mock `document`
         $document = $this->createMock('\Unikorp\KongAdminApi\Document\Sni');
 
+        // stub `set created at` method from `document` mock
+        $document->expects($this->once())
+            ->method('setCreatedAt')
+            ->with($this->isType('int'));
+
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')

--- a/tests/Unit/Node/UpstreamTest.php
+++ b/tests/Unit/Node/UpstreamTest.php
@@ -238,6 +238,11 @@ class UpstreamTest extends TestCase
         // mock `document`
         $document = $this->createMock('\Unikorp\KongAdminApi\Document\Upstream');
 
+        // stub `set created at` method from `document` mock
+        $document->expects($this->once())
+            ->method('setCreatedAt')
+            ->with($this->isType('int'));
+
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')


### PR DESCRIPTION
# Description

Handle `created_at` field on documents
Also set `created_at` in `put` request

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | yes
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | ~
| License        | MIT
