### PR TITLE
feat(document): handle size and offset fields

### DIFF
--- a/src/AbstractDocument.php
+++ b/src/AbstractDocument.php
@@ -22,13 +22,25 @@ abstract class AbstractDocument implements DocumentInterface
      * default fields
      * @const array DEFAULT_FIELDS
      */
-    const DEFAULT_FIELDS = ['createdAt'];
+    const DEFAULT_FIELDS = ['createdAt', 'size', 'offset'];
 
     /**
      * created at
      * @param int $createdAt
      */
     protected $createdAt = null;
+
+    /**
+     * size
+     * @param int $size
+     */
+    protected $size = null;
+
+    /**
+     * offset
+     * @param string $offset
+     */
+    protected $offset = null;
 
     /**
      * get fields
@@ -44,7 +56,7 @@ abstract class AbstractDocument implements DocumentInterface
      *
      * @return this
      */
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt(int $createdAt)
     {
         $this->createdAt = $createdAt;
 
@@ -59,6 +71,54 @@ abstract class AbstractDocument implements DocumentInterface
     public function getCreatedAt(): int
     {
         return $this->createdAt;
+    }
+
+    /**
+     * set size
+     *
+     * @param int $size
+     *
+     * @return this
+     */
+    public function setSize(int $size)
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * get size
+     *
+     * @return int
+     */
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    /**
+     * set offset
+     *
+     * @param string $offset
+     *
+     * @return this
+     */
+    public function setOffset(string $offset)
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    /**
+     * get offset
+     *
+     * @return string
+     */
+    public function getOffset(): string
+    {
+        return $this->offset;
     }
 
     /**

--- a/tests/Unit/Document/ApiTest.php
+++ b/tests/Unit/Document/ApiTest.php
@@ -542,6 +542,77 @@ class ApiTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -567,10 +638,12 @@ class ApiTest extends TestCase
             ->setUpstreamReadTimeout(10000)
             ->setHttpsOnly(true)
             ->setHttpIfTerminated(false)
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            '{"name":"name","hosts":"hosts","uris":"uris","methods":"methods","upstream_url":"upstreamUrl","strip_uri":false,"preserve_host":true,"retries":10,"upstream_connect_timeout":10000,"upstream_send_timeout":10000,"upstream_read_timeout":10000,"https_only":true,"http_if_terminated":false,"created_at":42}',
+            '{"name":"name","hosts":"hosts","uris":"uris","methods":"methods","upstream_url":"upstreamUrl","strip_uri":false,"preserve_host":true,"retries":10,"upstream_connect_timeout":10000,"upstream_send_timeout":10000,"upstream_read_timeout":10000,"https_only":true,"http_if_terminated":false,"created_at":42,"size":50,"offset":"offset"}',
             $this->document->toJson()
         );
     }
@@ -601,10 +674,12 @@ class ApiTest extends TestCase
             ->setUpstreamReadTimeout(10000)
             ->setHttpsOnly(true)
             ->setHttpIfTerminated(false)
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            'name=name&hosts=hosts&uris=uris&methods=methods&upstream_url=upstreamUrl&strip_uri=0&preserve_host=1&retries=10&upstream_connect_timeout=10000&upstream_send_timeout=10000&upstream_read_timeout=10000&https_only=1&http_if_terminated=0&created_at=42',
+            'name=name&hosts=hosts&uris=uris&methods=methods&upstream_url=upstreamUrl&strip_uri=0&preserve_host=1&retries=10&upstream_connect_timeout=10000&upstream_send_timeout=10000&upstream_read_timeout=10000&https_only=1&http_if_terminated=0&created_at=42&size=50&offset=offset',
             $this->document->toQueryString()
         );
     }

--- a/tests/Unit/Document/CertificateTest.php
+++ b/tests/Unit/Document/CertificateTest.php
@@ -192,6 +192,77 @@ class CertificateTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -207,10 +278,12 @@ class CertificateTest extends TestCase
             ->setCert('cert')
             ->setKey('key')
             ->setSnis('snis')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            '{"cert":"cert","key":"key","snis":"snis","created_at":42}',
+            '{"cert":"cert","key":"key","snis":"snis","created_at":42,"size":50,"offset":"offset"}',
             $this->document->toJson()
         );
     }
@@ -231,10 +304,12 @@ class CertificateTest extends TestCase
             ->setCert('cert')
             ->setKey('key')
             ->setSnis('snis')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            'cert=cert&key=key&snis=snis&created_at=42',
+            'cert=cert&key=key&snis=snis&created_at=42&size=50&offset=offset',
             $this->document->toQueryString()
         );
     }

--- a/tests/Unit/Document/ClusterTest.php
+++ b/tests/Unit/Document/ClusterTest.php
@@ -157,6 +157,77 @@ class ClusterTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -171,9 +242,14 @@ class ClusterTest extends TestCase
         $this->document
             ->setName('name')
             ->setAddress('address')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
-        $this->assertSame('{"name":"name","address":"address","created_at":42}', $this->document->toJson());
+        $this->assertSame(
+            '{"name":"name","address":"address","created_at":42,"size":50,"offset":"offset"}',
+            $this->document->toJson()
+        );
     }
 
     /**
@@ -191,8 +267,13 @@ class ClusterTest extends TestCase
         $this->document
             ->setName('name')
             ->setAddress('address')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
-        $this->assertSame('name=name&address=address&created_at=42', $this->document->toQueryString());
+        $this->assertSame(
+            'name=name&address=address&created_at=42&size=50&offset=offset',
+            $this->document->toQueryString()
+        );
     }
 }

--- a/tests/Unit/Document/ConsumerTest.php
+++ b/tests/Unit/Document/ConsumerTest.php
@@ -164,6 +164,77 @@ class ConsumerTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -178,8 +249,14 @@ class ConsumerTest extends TestCase
         $this->document
             ->setUsername('username')
             ->setCustomId('customId')
-            ->setCreatedAt(42);
-        $this->assertSame('{"username":"username","custom_id":"customId","created_at":42}', $this->document->toJson());
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
+
+        $this->assertSame(
+            '{"username":"username","custom_id":"customId","created_at":42,"size":50,"offset":"offset"}',
+            $this->document->toJson()
+        );
     }
 
     /**
@@ -197,8 +274,13 @@ class ConsumerTest extends TestCase
         $this->document
             ->setUsername('username')
             ->setCustomId('customId')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
-        $this->assertSame('username=username&custom_id=customId&created_at=42', $this->document->toQueryString());
+        $this->assertSame(
+            'username=username&custom_id=customId&created_at=42&size=50&offset=offset',
+            $this->document->toQueryString()
+        );
     }
 }

--- a/tests/Unit/Document/InformationTest.php
+++ b/tests/Unit/Document/InformationTest.php
@@ -87,6 +87,77 @@ class InformationTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -97,9 +168,15 @@ class InformationTest extends TestCase
      */
     public function testToJson()
     {
-        $this->document->setCreatedAt(42);
+        $this->document
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
-        $this->assertSame('{"created_at":42}', $this->document->toJson());
+        $this->assertSame(
+            '{"created_at":42,"size":50,"offset":"offset"}',
+            $this->document->toJson()
+        );
     }
 
     /**
@@ -113,8 +190,14 @@ class InformationTest extends TestCase
      */
     public function testToQueryString()
     {
-        $this->document->setCreatedAt(42);
+        $this->document
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
-        $this->assertSame('created_at=42', $this->document->toQueryString());
+        $this->assertSame(
+            'created_at=42&size=50&offset=offset',
+            $this->document->toQueryString()
+        );
     }
 }

--- a/tests/Unit/Document/PluginTest.php
+++ b/tests/Unit/Document/PluginTest.php
@@ -242,6 +242,77 @@ class PluginTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -258,10 +329,12 @@ class PluginTest extends TestCase
             ->setConsumerId('consumerId')
             ->addConfig('test', true)
             ->addConfig('something_else', 'something_else')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            '{"name":"name","consumer_id":"consumerId","config.test":true,"config.something_else":"something_else","created_at":42}',
+            '{"name":"name","consumer_id":"consumerId","config.test":true,"config.something_else":"something_else","created_at":42,"size":50,"offset":"offset"}',
             $this->document->toJson()
         );
     }
@@ -283,10 +356,12 @@ class PluginTest extends TestCase
             ->setConsumerId('consumerId')
             ->addConfig('test', true)
             ->addConfig('something_else', 'something_else')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            'name=name&consumer_id=consumerId&config.test=1&config.something_else=something_else&created_at=42',
+            'name=name&consumer_id=consumerId&config.test=1&config.something_else=something_else&created_at=42&size=50&offset=offset',
             $this->document->toQueryString()
         );
     }

--- a/tests/Unit/Document/SniTest.php
+++ b/tests/Unit/Document/SniTest.php
@@ -157,6 +157,77 @@ class SniTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -171,10 +242,12 @@ class SniTest extends TestCase
         $this->document
             ->setName('name')
             ->setSslCertificateId('sslCertificateId')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            '{"name":"name","ssl_certificate_id":"sslCertificateId","created_at":42}',
+            '{"name":"name","ssl_certificate_id":"sslCertificateId","created_at":42,"size":50,"offset":"offset"}',
             $this->document->toJson()
         );
     }
@@ -194,10 +267,12 @@ class SniTest extends TestCase
         $this->document
             ->setName('name')
             ->setSslCertificateId('sslCertificateId')
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            'name=name&ssl_certificate_id=sslCertificateId&created_at=42',
+            'name=name&ssl_certificate_id=sslCertificateId&created_at=42&size=50&offset=offset',
             $this->document->toQueryString()
         );
     }

--- a/tests/Unit/Document/TargetTest.php
+++ b/tests/Unit/Document/TargetTest.php
@@ -157,6 +157,77 @@ class TargetTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -171,10 +242,12 @@ class TargetTest extends TestCase
         $this->document
             ->setTarget('target')
             ->setWeight(1000)
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            '{"target":"target","weight":1000,"created_at":42}',
+            '{"target":"target","weight":1000,"created_at":42,"size":50,"offset":"offset"}',
             $this->document->toJson()
         );
     }
@@ -194,10 +267,12 @@ class TargetTest extends TestCase
         $this->document
             ->setTarget('target')
             ->setWeight(1000)
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            'target=target&weight=1000&created_at=42',
+            'target=target&weight=1000&created_at=42&size=50&offset=offset',
             $this->document->toQueryString()
         );
     }

--- a/tests/Unit/Document/UpstreamTest.php
+++ b/tests/Unit/Document/UpstreamTest.php
@@ -192,6 +192,77 @@ class UpstreamTest extends TestCase
     }
 
     /**
+     * test set size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setSize
+     */
+    public function testSetSize()
+    {
+        // asserts
+        $this->document->setSize(42);
+        $this->assertSame(42, $this->readAttribute($this->document, 'size'));
+    }
+
+    /**
+     * test get size
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getSize
+     */
+    public function testGetSize()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `size` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('size');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 42);
+        $this->assertSame(42, $this->document->getSize());
+    }
+
+
+    /**
+     * test set offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::setOffset
+     */
+    public function testSetOffset()
+    {
+        // asserts
+        $this->document->setOffset('offset');
+        $this->assertSame('offset', $this->readAttribute($this->document, 'offset'));
+    }
+
+    /**
+     * test get offset
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\AbstractDocument::getOffset
+     */
+    public function testGetOffset()
+    {
+        // reflect `document`
+        $reflectionClass = new \ReflectionClass($this->document);
+
+        // set `offset` property from `document` accessible
+        $reflectionProperty = $reflectionClass->getProperty('offset');
+        $reflectionProperty->setAccessible(true);
+
+        // assert
+        $reflectionProperty->setValue($this->document, 'offset');
+        $this->assertSame('offset', $this->document->getOffset());
+    }
+
+    /**
      * test to json
      *
      * @return void
@@ -207,10 +278,12 @@ class UpstreamTest extends TestCase
             ->setName('name')
             ->setSlots(65536)
             ->setOrderlist([1, 2, 7, 9, 6, 3])
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            '{"name":"name","slots":65536,"orderlist":[1,2,7,9,6,3],"created_at":42}',
+            '{"name":"name","slots":65536,"orderlist":[1,2,7,9,6,3],"created_at":42,"size":50,"offset":"offset"}',
             $this->document->toJson()
         );
     }
@@ -231,10 +304,12 @@ class UpstreamTest extends TestCase
             ->setName('name')
             ->setSlots(65536)
             ->setOrderlist([1, 2, 7, 9, 6, 3])
-            ->setCreatedAt(42);
+            ->setCreatedAt(42)
+            ->setSize(50)
+            ->setOffset('offset');
 
         $this->assertSame(
-            'name=name&slots=65536&orderlist%5B0%5D=1&orderlist%5B1%5D=2&orderlist%5B2%5D=7&orderlist%5B3%5D=9&orderlist%5B4%5D=6&orderlist%5B5%5D=3&created_at=42',
+            'name=name&slots=65536&orderlist%5B0%5D=1&orderlist%5B1%5D=2&orderlist%5B2%5D=7&orderlist%5B3%5D=9&orderlist%5B4%5D=6&orderlist%5B5%5D=3&created_at=42&size=50&offset=offset',
             $this->document->toQueryString()
         );
     }


### PR DESCRIPTION
# Description

Add `size`& `offset` as default fields in documents

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | yes
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | ~
| License        | MIT
