### PR TITLE
feat(node): allow to send params on get requests

### DIFF
--- a/src/AbstractNode.php
+++ b/src/AbstractNode.php
@@ -19,6 +19,14 @@ namespace Unikorp\KongAdminApi;
 abstract class AbstractNode implements NodeInterface
 {
     /**
+     * urlencoded content type
+     * @const array URLENCODED_CONTENT_TYPE
+     */
+    const URLENCODED_CONTENT_TYPE = [
+        'Content-Type' => 'application/x-www-form-urlencoded',
+    ];
+
+    /**
      * json content type
      * @const array JSON_CONTENT_TYPE
      */
@@ -49,9 +57,12 @@ abstract class AbstractNode implements NodeInterface
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    protected function get($endpoint)
+    protected function get($endpoint, DocumentInterface $document = null)
     {
-        return $this->client->getHttpClient()->get($endpoint);
+        return $this->client->getHttpClient()->get(
+            sprintf('%1$s?%2$s', $endpoint, $document ? $document->toQueryString() : ''),
+            self::URLENCODED_CONTENT_TYPE
+        );
     }
 
     /**

--- a/tests/Unit/Node/ApiTest.php
+++ b/tests/Unit/Node/ApiTest.php
@@ -142,7 +142,10 @@ class ApiTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/apis/test-api'))
+            ->with(
+                $this->equalTo('/apis/test-api?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -170,7 +173,10 @@ class ApiTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/apis/'))
+            ->with(
+                $this->equalTo('/apis/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/CertificateTest.php
+++ b/tests/Unit/Node/CertificateTest.php
@@ -142,7 +142,10 @@ class CertificateTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/certificates/test-certificate'))
+            ->with(
+                $this->equalTo('/certificates/test-certificate?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -170,7 +173,10 @@ class CertificateTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/certificates/'))
+            ->with(
+                $this->equalTo('/certificates/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/ClusterTest.php
+++ b/tests/Unit/Node/ClusterTest.php
@@ -102,7 +102,10 @@ class ClusterTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/cluster'))
+            ->with(
+                $this->equalTo('/cluster?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/ConsumerTest.php
+++ b/tests/Unit/Node/ConsumerTest.php
@@ -142,7 +142,10 @@ class ConsumerTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/consumers/test-consumer'))
+            ->with(
+                $this->equalTo('/consumers/test-consumer?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -170,7 +173,10 @@ class ConsumerTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/consumers/'))
+            ->with(
+                $this->equalTo('/consumers/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/InformationTest.php
+++ b/tests/Unit/Node/InformationTest.php
@@ -102,7 +102,10 @@ class InformationTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/'))
+            ->with(
+                $this->equalTo('/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -130,7 +133,10 @@ class InformationTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/status'))
+            ->with(
+                $this->equalTo('/status?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/PluginTest.php
+++ b/tests/Unit/Node/PluginTest.php
@@ -142,7 +142,10 @@ class PluginTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/plugins/test-plugin'))
+            ->with(
+                $this->equalTo('/plugins/test-plugin?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -170,7 +173,10 @@ class PluginTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/plugins/'))
+            ->with(
+                $this->equalTo('/plugins/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -198,7 +204,10 @@ class PluginTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/apis/test-api/plugins/'))
+            ->with(
+                $this->equalTo('/apis/test-api/plugins/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -343,7 +352,10 @@ class PluginTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/plugins/enabled'))
+            ->with(
+                $this->equalTo('/plugins/enabled?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -371,7 +383,10 @@ class PluginTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/plugins/schema/test-plugin'))
+            ->with(
+                $this->equalTo('/plugins/schema/test-plugin?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/SniTest.php
+++ b/tests/Unit/Node/SniTest.php
@@ -142,7 +142,10 @@ class SniTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/snis/test-sni'))
+            ->with(
+                $this->equalTo('/snis/test-sni?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -170,7 +173,10 @@ class SniTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/snis/'))
+            ->with(
+                $this->equalTo('/snis/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/TargetTest.php
+++ b/tests/Unit/Node/TargetTest.php
@@ -142,7 +142,10 @@ class TargetTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/upstreams/test-upstream/targets'))
+            ->with(
+                $this->equalTo('/upstreams/test-upstream/targets?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -170,7 +173,10 @@ class TargetTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/upstreams/test-upstream/targets/active'))
+            ->with(
+                $this->equalTo('/upstreams/test-upstream/targets/active?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);

--- a/tests/Unit/Node/UpstreamTest.php
+++ b/tests/Unit/Node/UpstreamTest.php
@@ -142,7 +142,10 @@ class UpstreamTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/upstreams/test-upstream'))
+            ->with(
+                $this->equalTo('/upstreams/test-upstream?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
@@ -170,7 +173,10 @@ class UpstreamTest extends TestCase
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('/upstreams/'))
+            ->with(
+                $this->equalTo('/upstreams/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);


### PR DESCRIPTION
# Description

Allow to send params on get requests

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | yes
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | ~
| License        | MIT
