### PR TITLE
refactor(node): rename nodes

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -44,15 +44,15 @@ class Configurator implements ConfiguratorInterface
     public function __construct()
     {
         $this->nodes = [
-            'api' => Node\Api::class,
-            'certificate' => Node\Certificate::class,
-            'cluster' => Node\Cluster::class,
-            'consumer' => Node\Consumer::class,
-            'information' => Node\Information::class,
-            'plugin' => Node\Plugin::class,
-            'sni' => Node\Sni::class,
-            'target' => Node\Target::class,
-            'upstream' => Node\Upstream::class,
+            'api' => Node\ApiNode::class,
+            'certificate' => Node\CertificateNode::class,
+            'cluster' => Node\ClusterNode::class,
+            'consumer' => Node\ConsumerNode::class,
+            'information' => Node\InformationNode::class,
+            'plugin' => Node\PluginNode::class,
+            'sni' => Node\SniNode::class,
+            'target' => Node\TargetNode::class,
+            'upstream' => Node\UpstreamNode::class,
         ];
     }
 

--- a/src/Node/ApiNode.php
+++ b/src/Node/ApiNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\ApiDocument as Document;
 
 /**
- * api
+ * api node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Api extends AbstractNode
+class ApiNode extends AbstractNode
 {
     /**
      * add api

--- a/src/Node/CertificateNode.php
+++ b/src/Node/CertificateNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\CertificateDocument as Document;
 
 /**
- * certificate
+ * certificate node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Certificate extends AbstractNode
+class CertificateNode extends AbstractNode
 {
     /**
      * add certificate

--- a/src/Node/ClusterNode.php
+++ b/src/Node/ClusterNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\ClusterDocument as Document;
 
 /**
- * cluster
+ * cluster node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Cluster extends AbstractNode
+class ClusterNode extends AbstractNode
 {
     /**
      * retrieve cluster status

--- a/src/Node/ConsumerNode.php
+++ b/src/Node/ConsumerNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\ConsumerDocument as Document;
 
 /**
- * consumer
+ * consumer node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Consumer extends AbstractNode
+class ConsumerNode extends AbstractNode
 {
     /**
      * create consumer

--- a/src/Node/InformationNode.php
+++ b/src/Node/InformationNode.php
@@ -15,11 +15,11 @@ use Psr\Http\Message\ResponseInterface;
 use Unikorp\KongAdminApi\AbstractNode;
 
 /**
- * information
+ * information node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Information extends AbstractNode
+class InformationNode extends AbstractNode
 {
     /**
      * retrieve node information

--- a/src/Node/PluginNode.php
+++ b/src/Node/PluginNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\PluginDocument as Document;
 
 /**
- * plugin
+ * plugin node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Plugin extends AbstractNode
+class PluginNode extends AbstractNode
 {
     /**
      * add plugin

--- a/src/Node/SniNode.php
+++ b/src/Node/SniNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\SniDocument as Document;
 
 /**
- * sni
+ * sni node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Sni extends AbstractNode
+class SniNode extends AbstractNode
 {
     /**
      * add sni

--- a/src/Node/TargetNode.php
+++ b/src/Node/TargetNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\TargetDocument as Document;
 
 /**
- * target
+ * target node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Target extends AbstractNode
+class TargetNode extends AbstractNode
 {
     /**
      * add target

--- a/src/Node/UpstreamNode.php
+++ b/src/Node/UpstreamNode.php
@@ -16,11 +16,11 @@ use Unikorp\KongAdminApi\AbstractNode;
 use Unikorp\KongAdminApi\Document\UpstreamDocument as Document;
 
 /**
- * upstream
+ * upstream node
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class Upstream extends AbstractNode
+class UpstreamNode extends AbstractNode
 {
     /**
      * add upstream

--- a/tests/Functional/ApiTest.php
+++ b/tests/Functional/ApiTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\ApiDocument as Document;
-use Unikorp\KongAdminApi\Node\Api as Node;
+use Unikorp\KongAdminApi\Node\ApiNode as Node;
 
 /**
  * api test
@@ -26,7 +26,7 @@ class ApiTest extends TestCase
 {
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Api $node
+     * @param \Unikorp\KongAdminApi\Node\ApiNode $node
      */
     private $node = null;
 
@@ -92,7 +92,7 @@ class ApiTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::addApi
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::addApi
      */
     public function testAddApi()
     {
@@ -124,7 +124,7 @@ class ApiTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::retrieveApi
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::retrieveApi
      */
     public function testRetrieveApi()
     {
@@ -148,7 +148,7 @@ class ApiTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::listApis
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::listApis
      */
     public function testListApis()
     {
@@ -183,7 +183,7 @@ class ApiTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::updateApi
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::updateApi
      */
     public function testUpdateApi()
     {
@@ -215,7 +215,7 @@ class ApiTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::updateOrCreateApi
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::updateOrCreateApi
      */
     public function testUpdateOrCreateApi()
     {
@@ -247,7 +247,7 @@ class ApiTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::deleteApi
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::deleteApi
      */
     public function testDeleteApi()
     {

--- a/tests/Functional/CertificateTest.php
+++ b/tests/Functional/CertificateTest.php
@@ -15,18 +15,18 @@ use PHPUnit\Framework\TestCase;
 use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\CertificateDocument as Document;
-use Unikorp\KongAdminApi\Node\Certificate as Node;
+use Unikorp\KongAdminApi\Node\CertificateNode as Node;
 
 /**
  * certificate test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class CertificateTest extends TestCase
+class CertificateNodeTest extends TestCase
 {
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Certificate $node
+     * @param \Unikorp\KongAdminApi\Node\CertificateNode $node
      */
     private $node = null;
 
@@ -84,7 +84,7 @@ class CertificateTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::addCertificate
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::addCertificate
      */
     public function testAddCertificate()
     {
@@ -111,7 +111,7 @@ class CertificateTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::retrieveCertificate
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::retrieveCertificate
      */
     public function testRetrieveCertificate()
     {
@@ -135,7 +135,7 @@ class CertificateTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::listCertificates
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::listCertificates
      */
     public function testListCertificates()
     {
@@ -161,7 +161,7 @@ class CertificateTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::updateCertificate
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::updateCertificate
      */
     public function testUpdateCertificate()
     {
@@ -191,7 +191,7 @@ class CertificateTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::updateOrCreateCertificate
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::updateOrCreateCertificate
      */
     public function testUpdateOrCreateCertificate()
     {
@@ -218,7 +218,7 @@ class CertificateTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::deleteCertificate
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::deleteCertificate
      */
     public function testDeleteCertificate()
     {

--- a/tests/Functional/ClusterTest.php
+++ b/tests/Functional/ClusterTest.php
@@ -15,18 +15,18 @@ use PHPUnit\Framework\TestCase;
 use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\ClusterDocument as Document;
-use Unikorp\KongAdminApi\Node\Cluster as Node;
+use Unikorp\KongAdminApi\Node\ClusterNode as Node;
 
 /**
  * cluster test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class ClusterTest extends TestCase
+class ClusterNodeTest extends TestCase
 {
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Cluster $node
+     * @param \Unikorp\KongAdminApi\Node\ClusterNode $node
      */
     private $node = null;
 
@@ -70,7 +70,7 @@ class ClusterTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Cluster::retrieveClusterStatus
+     * @covers \Unikorp\KongAdminApi\Node\ClusterNode::retrieveClusterStatus
      */
     public function testRetrieveClusterStatus()
     {
@@ -90,7 +90,7 @@ class ClusterTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Cluster::addANode
+     * @covers \Unikorp\KongAdminApi\Node\ClusterNode::addANode
      */
     public function testAddANode()
     {
@@ -116,7 +116,7 @@ class ClusterTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Cluster::forciblyRemoveANode
+     * @covers \Unikorp\KongAdminApi\Node\ClusterNode::forciblyRemoveANode
      */
     public function testForciblyRemoveANode()
     {

--- a/tests/Functional/ConsumerTest.php
+++ b/tests/Functional/ConsumerTest.php
@@ -15,18 +15,18 @@ use PHPUnit\Framework\TestCase;
 use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\ConsumerDocument as Document;
-use Unikorp\KongAdminApi\Node\Consumer as Node;
+use Unikorp\KongAdminApi\Node\ConsumerNode as Node;
 
 /**
  * consumer test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class ConsumerTest extends TestCase
+class ConsumerNodeTest extends TestCase
 {
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Consumer $node
+     * @param \Unikorp\KongAdminApi\Node\ConsumerNode $node
      */
     private $node = null;
 
@@ -88,7 +88,7 @@ class ConsumerTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::createConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::createConsumer
      */
     public function testCreateConsumer()
     {
@@ -113,7 +113,7 @@ class ConsumerTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::retrieveConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::retrieveConsumer
      */
     public function testRetrieveConsumer()
     {
@@ -133,7 +133,7 @@ class ConsumerTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::listConsumers
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::listConsumers
      */
     public function testlistConsumers()
     {
@@ -168,7 +168,7 @@ class ConsumerTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::updateConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::updateConsumer
      */
     public function testUpdateConsumer()
     {
@@ -193,7 +193,7 @@ class ConsumerTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::updateOrCreateConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::updateOrCreateConsumer
      */
     public function testUpdateOrCreateConsumer()
     {
@@ -218,7 +218,7 @@ class ConsumerTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::deleteConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::deleteConsumer
      */
     public function testDeleteConsumer()
     {

--- a/tests/Functional/InformationTest.php
+++ b/tests/Functional/InformationTest.php
@@ -14,18 +14,18 @@ namespace Unikorp\KongAdminApi\Tests\Functional;
 use PHPUnit\Framework\TestCase;
 use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
-use Unikorp\KongAdminApi\Node\Information as Node;
+use Unikorp\KongAdminApi\Node\InformationNode as Node;
 
 /**
  * information test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class InformationTest extends TestCase
+class InformationNodeTest extends TestCase
 {
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Information $node
+     * @param \Unikorp\KongAdminApi\Node\InformationNode $node
      */
     private $node = null;
 
@@ -69,7 +69,7 @@ class InformationTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Information::retrieveNodeInformation
+     * @covers \Unikorp\KongAdminApi\Node\InformationNode::retrieveNodeInformation
      */
     public function testRetreiveNodeInformation()
     {
@@ -89,7 +89,7 @@ class InformationTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Information::retrieveNodeStatus
+     * @covers \Unikorp\KongAdminApi\Node\InformationNode::retrieveNodeStatus
      */
     public function testRetreiveNodeStatus()
     {

--- a/tests/Functional/PluginTest.php
+++ b/tests/Functional/PluginTest.php
@@ -16,14 +16,14 @@ use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\ApiDocument;
 use Unikorp\KongAdminApi\Document\PluginDocument as Document;
-use Unikorp\KongAdminApi\Node\Plugin as Node;
+use Unikorp\KongAdminApi\Node\PluginNode as Node;
 
 /**
  * plugin test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class PluginTest extends TestCase
+class PluginNodeTest extends TestCase
 {
     /**
      * client
@@ -33,7 +33,7 @@ class PluginTest extends TestCase
 
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Plugin $node
+     * @param \Unikorp\KongAdminApi\Node\PluginNode $node
      */
     private $node = null;
 
@@ -115,7 +115,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::addPlugin
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::addPlugin
      */
     public function testAddPlugin()
     {
@@ -144,7 +144,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::retrievePlugin
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::retrievePlugin
      */
     public function testRetrievePlugin()
     {
@@ -171,7 +171,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::listAllPlugins
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::listAllPlugins
      */
     public function testListAllPlugins()
     {
@@ -206,7 +206,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::listPluginsPerApi
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::listPluginsPerApi
      */
     public function testListPluginsPerApi()
     {
@@ -228,7 +228,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::updatePlugin
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::updatePlugin
      */
     public function testUpdatePlugin()
     {
@@ -262,7 +262,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::updateOrAddPlugin
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::updateOrAddPlugin
      */
     public function testUpdateOrAddPlugin()
     {
@@ -316,7 +316,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::deletePlugin
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::deletePlugin
      */
     public function testDeletePlugin()
     {
@@ -335,7 +335,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::retrieveEnabledPlugin
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::retrieveEnabledPlugin
      */
     public function testRetrieveEnabledPlugin()
     {
@@ -384,7 +384,7 @@ class PluginTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::retrievePluginSchema
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::retrievePluginSchema
      */
     public function testRetrievePluginSchema()
     {

--- a/tests/Functional/SniTest.php
+++ b/tests/Functional/SniTest.php
@@ -16,14 +16,14 @@ use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\CertificateDocument;
 use Unikorp\KongAdminApi\Document\SniDocument as Document;
-use Unikorp\KongAdminApi\Node\Sni as Node;
+use Unikorp\KongAdminApi\Node\SniNode as Node;
 
 /**
  * sni test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class SniTest extends TestCase
+class SniNodeTest extends TestCase
 {
     /**
      * client
@@ -33,7 +33,7 @@ class SniTest extends TestCase
 
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Sni $node
+     * @param \Unikorp\KongAdminApi\Node\SniNode $node
      */
     private $node = null;
 
@@ -104,7 +104,7 @@ class SniTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::addSni
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::addSni
      */
     public function testAddSni()
     {
@@ -129,7 +129,7 @@ class SniTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::retrieveSni
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::retrieveSni
      */
     public function testRetrieveSni()
     {
@@ -149,7 +149,7 @@ class SniTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::listSnis
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::listSnis
      */
     public function testListSnis()
     {
@@ -174,7 +174,7 @@ class SniTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::updateSni
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::updateSni
      */
     public function testUpdateSni()
     {
@@ -203,7 +203,7 @@ class SniTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::updateOrCreateSni
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::updateOrCreateSni
      */
     public function testUpdateOrCreateSni()
     {
@@ -226,7 +226,7 @@ class SniTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::deleteSni
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::deleteSni
      */
     public function testDeleteSni()
     {

--- a/tests/Functional/TargetTest.php
+++ b/tests/Functional/TargetTest.php
@@ -16,14 +16,14 @@ use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\TargetDocument as Document;
 use Unikorp\KongAdminApi\Document\UpstreamDocument;
-use Unikorp\KongAdminApi\Node\Target as Node;
+use Unikorp\KongAdminApi\Node\TargetNode as Node;
 
 /**
  * target test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class TargetTest extends TestCase
+class TargetNodeTest extends TestCase
 {
     /**
      * client
@@ -33,7 +33,7 @@ class TargetTest extends TestCase
 
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Target $node
+     * @param \Unikorp\KongAdminApi\Node\TargetNode $node
      */
     private $node = null;
 
@@ -108,7 +108,7 @@ class TargetTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::addTarget
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::addTarget
      */
     public function testAddTarget()
     {
@@ -133,7 +133,7 @@ class TargetTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::listTargets
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::listTargets
      */
     public function testListTargets()
     {
@@ -169,7 +169,7 @@ class TargetTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::listActiveTargets
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::listActiveTargets
      */
     public function testListActiveTargets()
     {
@@ -195,7 +195,7 @@ class TargetTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::deleteTarget
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::deleteTarget
      */
     public function testDeleteTarget()
     {

--- a/tests/Functional/UpstreamTest.php
+++ b/tests/Functional/UpstreamTest.php
@@ -15,18 +15,18 @@ use PHPUnit\Framework\TestCase;
 use Unikorp\KongAdminApi\Client;
 use Unikorp\KongAdminApi\Configurator;
 use Unikorp\KongAdminApi\Document\UpstreamDocument as Document;
-use Unikorp\KongAdminApi\Node\Upstream as Node;
+use Unikorp\KongAdminApi\Node\UpstreamNode as Node;
 
 /**
  * upstream test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class UpstreamTest extends TestCase
+class UpstreamNodeTest extends TestCase
 {
     /**
      * node
-     * @param \Unikorp\KongAdminApi\Node\Upstream $node
+     * @param \Unikorp\KongAdminApi\Node\UpstreamNode $node
      */
     private $node = null;
 
@@ -88,7 +88,7 @@ class UpstreamTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::addUpstream
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::addUpstream
      */
     public function testAddUpstream()
     {
@@ -113,7 +113,7 @@ class UpstreamTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::retrieveUpstream
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::retrieveUpstream
      */
     public function testRetrieveUpstream()
     {
@@ -133,7 +133,7 @@ class UpstreamTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::listUpstreams
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::listUpstreams
      */
     public function testListUpstreams()
     {
@@ -167,7 +167,7 @@ class UpstreamTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::updateUpstream
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::updateUpstream
      */
     public function testUpdateUpstream()
     {
@@ -192,7 +192,7 @@ class UpstreamTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::updateOrCreateUpstream
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::updateOrCreateUpstream
      */
     public function testUpdateOrCreateUpstream()
     {
@@ -217,7 +217,7 @@ class UpstreamTest extends TestCase
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::deleteUpstream
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::deleteUpstream
      */
     public function testDeleteUpstream()
     {

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -259,10 +259,14 @@ class ClientTest extends TestCase
      */
     public function validNodeNameProvider()
     {
-        yield ['api', '\Unikorp\KongAdminApi\Node\Api'];
-        yield ['cluster', '\Unikorp\KongAdminApi\Node\Cluster'];
-        yield ['consumer', '\Unikorp\KongAdminApi\Node\Consumer'];
-        yield ['information', '\Unikorp\KongAdminApi\Node\Information'];
-        yield ['plugin', '\Unikorp\KongAdminApi\Node\Plugin'];
+        yield ['api', '\Unikorp\KongAdminApi\Node\ApiNode'];
+        yield ['certificate', '\Unikorp\KongAdminApi\Node\CertificateNode'];
+        yield ['cluster', '\Unikorp\KongAdminApi\Node\ClusterNode'];
+        yield ['consumer', '\Unikorp\KongAdminApi\Node\ConsumerNode'];
+        yield ['information', '\Unikorp\KongAdminApi\Node\InformationNode'];
+        yield ['plugin', '\Unikorp\KongAdminApi\Node\PluginNode'];
+        yield ['sni', '\Unikorp\KongAdminApi\Node\SniNode'];
+        yield ['target', '\Unikorp\KongAdminApi\Node\TargetNode'];
+        yield ['upstream', '\Unikorp\KongAdminApi\Node\UpstreamNode'];
     }
 }

--- a/tests/Unit/ConfiguratorTest.php
+++ b/tests/Unit/ConfiguratorTest.php
@@ -79,15 +79,15 @@ class ConfiguratorTest extends TestCase
         $this->assertArrayHasKey('sni', $nodes);
         $this->assertArrayHasKey('target', $nodes);
         $this->assertArrayHasKey('upstream', $nodes);
-        $this->assertSame(Node\Api::class, $nodes['api']);
-        $this->assertSame(Node\Certificate::class, $nodes['certificate']);
-        $this->assertSame(Node\Cluster::class, $nodes['cluster']);
-        $this->assertSame(Node\Consumer::class, $nodes['consumer']);
-        $this->assertSame(Node\Information::class, $nodes['information']);
-        $this->assertSame(Node\Plugin::class, $nodes['plugin']);
-        $this->assertSame(Node\Sni::class, $nodes['sni']);
-        $this->assertSame(Node\Target::class, $nodes['target']);
-        $this->assertSame(Node\Upstream::class, $nodes['upstream']);
+        $this->assertSame(Node\ApiNode::class, $nodes['api']);
+        $this->assertSame(Node\CertificateNode::class, $nodes['certificate']);
+        $this->assertSame(Node\ClusterNode::class, $nodes['cluster']);
+        $this->assertSame(Node\ConsumerNode::class, $nodes['consumer']);
+        $this->assertSame(Node\InformationNode::class, $nodes['information']);
+        $this->assertSame(Node\PluginNode::class, $nodes['plugin']);
+        $this->assertSame(Node\SniNode::class, $nodes['sni']);
+        $this->assertSame(Node\TargetNode::class, $nodes['target']);
+        $this->assertSame(Node\UpstreamNode::class, $nodes['upstream']);
     }
 
     /**
@@ -185,12 +185,12 @@ class ConfiguratorTest extends TestCase
         $reflectionProperty->setAccessible(true);
 
         // add node
-        $this->configurator->addNode('test', '\Unikorp\KongAdminApi\Node\Information');
+        $this->configurator->addNode('test', Node\InformationNode::class);
 
         // assert
         $nodes = $reflectionProperty->getValue($this->configurator);
         $this->assertArrayHasKey('test', $nodes);
-        $this->assertSame('\Unikorp\KongAdminApi\Node\Information', $nodes['test']);
+        $this->assertSame(Node\InformationNode::class, $nodes['test']);
     }
 
     /**
@@ -204,7 +204,7 @@ class ConfiguratorTest extends TestCase
      */
     public function testAddNodeWhenAlreadyExists()
     {
-        $this->configurator->addNode('api', '\Unikorp\KongAdminApi\Node\Api');
+        $this->configurator->addNode('api', Node\ApiNode::class);
     }
 
     /**
@@ -253,7 +253,7 @@ class ConfiguratorTest extends TestCase
      */
     public function testGetNodeWhenValidName()
     {
-        $this->assertSame(Node\Api::class, $this->configurator->getNode('api'));
+        $this->assertSame(Node\ApiNode::class, $this->configurator->getNode('api'));
     }
 
     /**

--- a/tests/Unit/Node/ApiNodeTest.php
+++ b/tests/Unit/Node/ApiNodeTest.php
@@ -11,16 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\ConsumerDocument as Document;
-use Unikorp\KongAdminApi\Node\Consumer as Node;
+use Unikorp\KongAdminApi\Document\ApiDocument as Document;
+use Unikorp\KongAdminApi\Node\ApiNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * consumer test
+ * api node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class ConsumerTest extends TestCase
+class ApiNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +83,14 @@ class ConsumerTest extends TestCase
     }
 
     /**
-     * test create consumer
+     * test add api
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::createConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::addApi
      * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testCreateConsumer()
+    public function testAddApi()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -112,25 +112,25 @@ class ConsumerTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('/consumers/'),
+                $this->equalTo('/apis/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->createConsumer($document);
+        $node->addApi($document);
     }
 
     /**
-     * test retrieve consumer
+     * test retrieve api
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::retrieveConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::retrieveApi
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrieveConsumer()
+    public function testRetrieveApi()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -144,24 +144,24 @@ class ConsumerTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/consumers/test-consumer?'),
+                $this->equalTo('/apis/test-api?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveConsumer('test-consumer');
+        $node->retrieveApi('test-api');
     }
 
     /**
-     * test list consumers
+     * test list apis
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::listConsumers
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::listApis
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListConsumers()
+    public function testListApis()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -175,75 +175,75 @@ class ConsumerTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/consumers/?'),
+                $this->equalTo('/apis/?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listConsumers();
+        $node->listApis();
     }
 
     /**
-     * test update consumer
+     * test update api
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::updateConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::updateApi
      * @covers \Unikorp\KongAdminApi\AbstractNode::patch
      */
-    public function testUpdateConsumer()
+    public function testUpdateApi()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
             ->method('getHttpClient')
             ->will($this->returnValue($this->httpClient));
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
         // mock `document`
         $document = $this->createMock(Document::class);
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')
             ->will($this->returnValue('{"test":true}'));
 
-        // stub `patch` method from `http client` mock
+        // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('patch')
             ->with(
-                $this->equalTo('/consumers/test-consumer'),
+                $this->equalTo('/apis/test-api'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateConsumer('test-consumer', $document);
+        $node->updateApi('test-api', $document);
     }
 
     /**
-     * test update or create consumer
+     * test update or create api
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::updateOrCreateConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::updateOrCreateApi
      * @covers \Unikorp\KongAdminApi\AbstractNode::put
      */
-    public function testUpdateOrCreateConsumer()
+    public function testUpdateOrCreateApi()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
             ->method('getHttpClient')
             ->will($this->returnValue($this->httpClient));
 
-        // mock `document`
-        $document = $this->createMock(Document::class);
-
         // mock `response`
         $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // mock `document`
+        $document = $this->createMock(Document::class);
 
         // stub `set created at` method from `document` mock
         $document->expects($this->once())
@@ -255,29 +255,29 @@ class ConsumerTest extends TestCase
             ->method('toJson')
             ->will($this->returnValue('{"test":true}'));
 
-        // stub `put` method from `http client` mock
+        // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('put')
             ->with(
-                $this->equalTo('/consumers/'),
+                $this->equalTo('/apis/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateOrCreateConsumer($document);
+        $node->updateOrCreateApi($document);
     }
 
     /**
-     * test delete consumer
+     * test delete api
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Consumer::deleteConsumer
+     * @covers \Unikorp\KongAdminApi\Node\ApiNode::deleteApi
      * @covers \Unikorp\KongAdminApi\AbstractNode::delete
      */
-    public function testDeleteConsumer()
+    public function testDeleteApi()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -287,17 +287,17 @@ class ConsumerTest extends TestCase
         // mock `response`
         $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
-        // stub `delete` method from `http client` mock
+        // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/consumers/test-consumer'),
+                $this->equalTo('/apis/test-api'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('[]')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->deleteConsumer('test-consumer');
+        $node->deleteApi('test-api');
     }
 }

--- a/tests/Unit/Node/CertificateNodeTest.php
+++ b/tests/Unit/Node/CertificateNodeTest.php
@@ -11,16 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\ApiDocument as Document;
-use Unikorp\KongAdminApi\Node\Api as Node;
+use Unikorp\KongAdminApi\Document\CertificateDocument as Document;
+use Unikorp\KongAdminApi\Node\CertificateNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * api test
+ * certificate node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class ApiTest extends TestCase
+class CertificateNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +83,14 @@ class ApiTest extends TestCase
     }
 
     /**
-     * test add api
+     * test add certificate
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::addApi
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::addCertificate
      * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testAddApi()
+    public function testAddCertificate()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -112,25 +112,25 @@ class ApiTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('/apis/'),
+                $this->equalTo('/certificates/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->addApi($document);
+        $node->addCertificate($document);
     }
 
     /**
-     * test retrieve api
+     * test retrieve certificate
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::retrieveApi
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::retrieveCertificate
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrieveApi()
+    public function testRetrieveCertificate()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -144,24 +144,24 @@ class ApiTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/apis/test-api?'),
+                $this->equalTo('/certificates/test-certificate?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveApi('test-api');
+        $node->retrieveCertificate('test-certificate');
     }
 
     /**
-     * test list apis
+     * test list certificates
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::listApis
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::listCertificates
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListApis()
+    public function testListCertificates()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -175,24 +175,24 @@ class ApiTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/apis/?'),
+                $this->equalTo('/certificates/?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listApis();
+        $node->listCertificates();
     }
 
     /**
-     * test update api
+     * test update certificate
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::updateApi
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::updateCertificate
      * @covers \Unikorp\KongAdminApi\AbstractNode::patch
      */
-    public function testUpdateApi()
+    public function testUpdateCertificate()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -214,25 +214,25 @@ class ApiTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('patch')
             ->with(
-                $this->equalTo('/apis/test-api'),
+                $this->equalTo('/certificates/test-certificate'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateApi('test-api', $document);
+        $node->updateCertificate('test-certificate', $document);
     }
 
     /**
-     * test update or create api
+     * test update or create certificate
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::updateOrCreateApi
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::updateOrCreateCertificate
      * @covers \Unikorp\KongAdminApi\AbstractNode::put
      */
-    public function testUpdateOrCreateApi()
+    public function testUpdateOrCreateCertificate()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -259,25 +259,25 @@ class ApiTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('put')
             ->with(
-                $this->equalTo('/apis/'),
+                $this->equalTo('/certificates/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateOrCreateApi($document);
+        $node->updateOrCreateCertificate($document);
     }
 
     /**
-     * test delete api
+     * test delete certificate
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Api::deleteApi
+     * @covers \Unikorp\KongAdminApi\Node\CertificateNode::deleteCertificate
      * @covers \Unikorp\KongAdminApi\AbstractNode::delete
      */
-    public function testDeleteApi()
+    public function testDeleteCertificate()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -291,13 +291,13 @@ class ApiTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/apis/test-api'),
+                $this->equalTo('/certificates/test-certificate'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('[]')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->deleteApi('test-api');
+        $node->deleteCertificate('test-certificate');
     }
 }

--- a/tests/Unit/Node/ClusterNodeTest.php
+++ b/tests/Unit/Node/ClusterNodeTest.php
@@ -11,15 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Node\Information as Node;
+use Unikorp\KongAdminApi\Document\ClusterDocument as Document;
+use Unikorp\KongAdminApi\Node\ClusterNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * information test
+ * cluster node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class InformationTest extends TestCase
+class ClusterNodeTest extends TestCase
 {
     /**
      * client
@@ -82,14 +83,14 @@ class InformationTest extends TestCase
     }
 
     /**
-     * test retrieve node information
+     * test retrieve cluster status
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Information::retrieveNodeInformation
+     * @covers \Unikorp\KongAdminApi\Node\ClusterNode::retrieveClusterStatus
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrieveNodeInformation()
+    public function testRetrieveClusterStatus()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -103,43 +104,92 @@ class InformationTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/?'),
+                $this->equalTo('/cluster?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveNodeInformation();
+        $node->retrieveClusterStatus();
     }
 
     /**
-     * test retrieve node status
+     * test add a node
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Information::retrieveNodeStatus
-     * @covers \Unikorp\KongAdminApi\AbstractNode::get
+     * @covers \Unikorp\KongAdminApi\Node\ClusterNode::addANode
+     * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testRetrieveNodeStatus()
+    public function testAddANode()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
             ->method('getHttpClient')
             ->will($this->returnValue($this->httpClient));
 
+        // mock `document`
+        $document = $this->createMock(Document::class);
+
         // mock `response`
         $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
-        // stub `get` method from `http client` mock
+        // stub `to json` method from `document` mock
+        $document->expects($this->once())
+            ->method('toJson')
+            ->will($this->returnValue('{"test":true}'));
+
+        // stub `delete` method from `http client` mock
         $this->httpClient->expects($this->once())
-            ->method('get')
+            ->method('post')
             ->with(
-                $this->equalTo('/status?'),
-                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+                $this->equalTo('/cluster'),
+                $this->equalTo(['Content-Type' => 'application/json']),
+                $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveNodeStatus();
+        $node->addANode($document);
+    }
+
+    /**
+     * test forcibly remove a node
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Node\ClusterNode::forciblyRemoveANode
+     * @covers \Unikorp\KongAdminApi\AbstractNode::delete
+     */
+    public function testForciblyRemoveANode()
+    {
+        // stub `get http client` method from `client` mock
+        $this->client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($this->httpClient));
+
+        // mock `document`
+        $document = $this->createMock(Document::class);
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // stub `to json` method from `document` mock
+        $document->expects($this->once())
+            ->method('toJson')
+            ->will($this->returnValue('{"test":true}'));
+
+        // stub `delete` method from `http client` mock
+        $this->httpClient->expects($this->once())
+            ->method('delete')
+            ->with(
+                $this->equalTo('/cluster'),
+                $this->equalTo(['Content-Type' => 'application/json']),
+                $this->equalTo('{"test":true}')
+            )
+            ->will($this->returnValue($response));
+
+        $node = new Node($this->client);
+        $node->forciblyRemoveANode($document);
     }
 }

--- a/tests/Unit/Node/ConsumerNodeTest.php
+++ b/tests/Unit/Node/ConsumerNodeTest.php
@@ -11,16 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\PluginDocument as Document;
-use Unikorp\KongAdminApi\Node\Plugin as Node;
+use Unikorp\KongAdminApi\Document\ConsumerDocument as Document;
+use Unikorp\KongAdminApi\Node\ConsumerNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * plugin test
+ * consumer node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class PluginTest extends TestCase
+class ConsumerNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +83,14 @@ class PluginTest extends TestCase
     }
 
     /**
-     * test add plugin
+     * test create consumer
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::addPlugin
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::createConsumer
      * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testAddPlugin()
+    public function testCreateConsumer()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -112,25 +112,25 @@ class PluginTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('/apis/test-plugin/plugins/'),
+                $this->equalTo('/consumers/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->addPlugin('test-plugin', $document);
+        $node->createConsumer($document);
     }
 
     /**
-     * test retrieve plugin
+     * test retrieve consumer
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::retrievePlugin
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::retrieveConsumer
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrievePlugin()
+    public function testRetrieveConsumer()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -144,24 +144,24 @@ class PluginTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/plugins/test-plugin?'),
+                $this->equalTo('/consumers/test-consumer?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrievePlugin('test-plugin');
+        $node->retrieveConsumer('test-consumer');
     }
 
     /**
-     * test list all plugins
+     * test list consumers
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::listAllPlugins
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::listConsumers
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListAllPlugins()
+    public function testListConsumers()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -175,55 +175,24 @@ class PluginTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/plugins/?'),
+                $this->equalTo('/consumers/?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listAllPlugins();
+        $node->listConsumers();
     }
 
     /**
-     * test list plugins per api
+     * test update consumer
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::listPluginsPerApi
-     * @covers \Unikorp\KongAdminApi\AbstractNode::get
-     */
-    public function testListPluginsPerApi()
-    {
-        // stub `get http client` method from `client` mock
-        $this->client->expects($this->once())
-            ->method('getHttpClient')
-            ->will($this->returnValue($this->httpClient));
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
-        // stub `get` method from `http client` mock
-        $this->httpClient->expects($this->once())
-            ->method('get')
-            ->with(
-                $this->equalTo('/apis/test-api/plugins/?'),
-                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
-            )
-            ->will($this->returnValue($response));
-
-        $node = new Node($this->client);
-        $node->listPluginsPerApi('test-api');
-    }
-
-    /**
-     * test update plugin
-     *
-     * @return void
-     *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::updatePlugin
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::updateConsumer
      * @covers \Unikorp\KongAdminApi\AbstractNode::patch
      */
-    public function testUpdatePlugin()
+    public function testUpdateConsumer()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -245,25 +214,25 @@ class PluginTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('patch')
             ->with(
-                $this->equalTo('/apis/test-api/plugins/id-plugin'),
+                $this->equalTo('/consumers/test-consumer'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updatePlugin('test-api', 'id-plugin', $document);
+        $node->updateConsumer('test-consumer', $document);
     }
 
     /**
-     * test update or add plugin
+     * test update or create consumer
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::updateOrAddPlugin
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::updateOrCreateConsumer
      * @covers \Unikorp\KongAdminApi\AbstractNode::put
      */
-    public function testUpdateOrAddPlugin()
+    public function testUpdateOrCreateConsumer()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -290,25 +259,25 @@ class PluginTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('put')
             ->with(
-                $this->equalTo('/apis/test-api/plugins/'),
+                $this->equalTo('/consumers/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateOrAddPlugin('test-api', $document);
+        $node->updateOrCreateConsumer($document);
     }
 
     /**
-     * test delete plugin
+     * test delete consumer
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::deletePlugin
+     * @covers \Unikorp\KongAdminApi\Node\ConsumerNode::deleteConsumer
      * @covers \Unikorp\KongAdminApi\AbstractNode::delete
      */
-    public function testDeletePlugin()
+    public function testDeleteConsumer()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -322,75 +291,13 @@ class PluginTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/apis/test-api/plugins/id-plugin'),
+                $this->equalTo('/consumers/test-consumer'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('[]')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->deletePlugin('test-api', 'id-plugin');
-    }
-
-    /**
-     * test retrieve enabled plugin
-     *
-     * @return void
-     *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::retrieveEnabledPlugin
-     * @covers \Unikorp\KongAdminApi\AbstractNode::get
-     */
-    public function testRetrieveEnabledPlugin()
-    {
-        // stub `get http client` method from `client` mock
-        $this->client->expects($this->once())
-            ->method('getHttpClient')
-            ->will($this->returnValue($this->httpClient));
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
-        // stub `get` method from `http client` mock
-        $this->httpClient->expects($this->once())
-            ->method('get')
-            ->with(
-                $this->equalTo('/plugins/enabled?'),
-                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
-            )
-            ->will($this->returnValue($response));
-
-        $node = new Node($this->client);
-        $node->retrieveEnabledPlugin();
-    }
-
-    /**
-     * test retrieve plugin schema
-     *
-     * @return void
-     *
-     * @covers \Unikorp\KongAdminApi\Node\Plugin::retrievePluginSchema
-     * @covers \Unikorp\KongAdminApi\AbstractNode::get
-     */
-    public function testRetrievePluginSchema()
-    {
-        // stub `get http client` method from `client` mock
-        $this->client->expects($this->once())
-            ->method('getHttpClient')
-            ->will($this->returnValue($this->httpClient));
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
-        // stub `get` method from `http client` mock
-        $this->httpClient->expects($this->once())
-            ->method('get')
-            ->with(
-                $this->equalTo('/plugins/schema/test-plugin?'),
-                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
-            )
-            ->will($this->returnValue($response));
-
-        $node = new Node($this->client);
-        $node->retrievePluginSchema('test-plugin');
+        $node->deleteConsumer('test-consumer');
     }
 }

--- a/tests/Unit/Node/InformationNodeTest.php
+++ b/tests/Unit/Node/InformationNodeTest.php
@@ -11,16 +11,15 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\ClusterDocument as Document;
-use Unikorp\KongAdminApi\Node\Cluster as Node;
+use Unikorp\KongAdminApi\Node\InformationNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * cluster test
+ * information node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class ClusterTest extends TestCase
+class InformationNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +82,14 @@ class ClusterTest extends TestCase
     }
 
     /**
-     * test retrieve cluster status
+     * test retrieve node information
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Cluster::retrieveClusterStatus
+     * @covers \Unikorp\KongAdminApi\Node\InformationNode::retrieveNodeInformation
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrieveClusterStatus()
+    public function testRetrieveNodeInformation()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -104,92 +103,43 @@ class ClusterTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/cluster?'),
+                $this->equalTo('/?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveClusterStatus();
+        $node->retrieveNodeInformation();
     }
 
     /**
-     * test add a node
+     * test retrieve node status
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Cluster::addANode
-     * @covers \Unikorp\KongAdminApi\AbstractNode::post
+     * @covers \Unikorp\KongAdminApi\Node\InformationNode::retrieveNodeStatus
+     * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testAddANode()
+    public function testRetrieveNodeStatus()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
             ->method('getHttpClient')
             ->will($this->returnValue($this->httpClient));
 
-        // mock `document`
-        $document = $this->createMock(Document::class);
-
         // mock `response`
         $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
-        // stub `to json` method from `document` mock
-        $document->expects($this->once())
-            ->method('toJson')
-            ->will($this->returnValue('{"test":true}'));
-
-        // stub `delete` method from `http client` mock
+        // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
-            ->method('post')
+            ->method('get')
             ->with(
-                $this->equalTo('/cluster'),
-                $this->equalTo(['Content-Type' => 'application/json']),
-                $this->equalTo('{"test":true}')
+                $this->equalTo('/status?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->addANode($document);
-    }
-
-    /**
-     * test forcibly remove a node
-     *
-     * @return void
-     *
-     * @covers \Unikorp\KongAdminApi\Node\Cluster::forciblyRemoveANode
-     * @covers \Unikorp\KongAdminApi\AbstractNode::delete
-     */
-    public function testForciblyRemoveANode()
-    {
-        // stub `get http client` method from `client` mock
-        $this->client->expects($this->once())
-            ->method('getHttpClient')
-            ->will($this->returnValue($this->httpClient));
-
-        // mock `document`
-        $document = $this->createMock(Document::class);
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
-        // stub `to json` method from `document` mock
-        $document->expects($this->once())
-            ->method('toJson')
-            ->will($this->returnValue('{"test":true}'));
-
-        // stub `delete` method from `http client` mock
-        $this->httpClient->expects($this->once())
-            ->method('delete')
-            ->with(
-                $this->equalTo('/cluster'),
-                $this->equalTo(['Content-Type' => 'application/json']),
-                $this->equalTo('{"test":true}')
-            )
-            ->will($this->returnValue($response));
-
-        $node = new Node($this->client);
-        $node->forciblyRemoveANode($document);
+        $node->retrieveNodeStatus();
     }
 }

--- a/tests/Unit/Node/PluginNodeTest.php
+++ b/tests/Unit/Node/PluginNodeTest.php
@@ -11,16 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\UpstreamDocument as Document;
-use Unikorp\KongAdminApi\Node\Upstream as Node;
+use Unikorp\KongAdminApi\Document\PluginDocument as Document;
+use Unikorp\KongAdminApi\Node\PluginNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * upstream test
+ * plugin node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class UpstreamTest extends TestCase
+class PluginNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +83,14 @@ class UpstreamTest extends TestCase
     }
 
     /**
-     * test add upstream
+     * test add plugin
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::addUpstream
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::addPlugin
      * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testAddUpstream()
+    public function testAddPlugin()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -112,25 +112,25 @@ class UpstreamTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('/upstreams/'),
+                $this->equalTo('/apis/test-plugin/plugins/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->addUpstream($document);
+        $node->addPlugin('test-plugin', $document);
     }
 
     /**
-     * test retrieve upstream
+     * test retrieve plugin
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::retrieveUpstream
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::retrievePlugin
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrieveUpstream()
+    public function testRetrievePlugin()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -144,24 +144,24 @@ class UpstreamTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/upstreams/test-upstream?'),
+                $this->equalTo('/plugins/test-plugin?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveUpstream('test-upstream');
+        $node->retrievePlugin('test-plugin');
     }
 
     /**
-     * test list upstreams
+     * test list all plugins
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::listUpstreams
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::listAllPlugins
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListUpstreams()
+    public function testListAllPlugins()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -175,75 +175,106 @@ class UpstreamTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/upstreams/?'),
+                $this->equalTo('/plugins/?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listUpstreams();
+        $node->listAllPlugins();
     }
 
     /**
-     * test update upstream
+     * test list plugins per api
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::updateUpstream
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::listPluginsPerApi
+     * @covers \Unikorp\KongAdminApi\AbstractNode::get
+     */
+    public function testListPluginsPerApi()
+    {
+        // stub `get http client` method from `client` mock
+        $this->client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($this->httpClient));
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // stub `get` method from `http client` mock
+        $this->httpClient->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/apis/test-api/plugins/?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
+            ->will($this->returnValue($response));
+
+        $node = new Node($this->client);
+        $node->listPluginsPerApi('test-api');
+    }
+
+    /**
+     * test update plugin
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::updatePlugin
      * @covers \Unikorp\KongAdminApi\AbstractNode::patch
      */
-    public function testUpdateUpstream()
+    public function testUpdatePlugin()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
             ->method('getHttpClient')
             ->will($this->returnValue($this->httpClient));
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
         // mock `document`
         $document = $this->createMock(Document::class);
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
         // stub `to json` method from `document` mock
         $document->expects($this->once())
             ->method('toJson')
             ->will($this->returnValue('{"test":true}'));
 
-        // stub `get` method from `http client` mock
+        // stub `patch` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('patch')
             ->with(
-                $this->equalTo('/upstreams/test-upstream'),
+                $this->equalTo('/apis/test-api/plugins/id-plugin'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateUpstream('test-upstream', $document);
+        $node->updatePlugin('test-api', 'id-plugin', $document);
     }
 
     /**
-     * test update or create upstream
+     * test update or add plugin
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::updateOrCreateUpstream
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::updateOrAddPlugin
      * @covers \Unikorp\KongAdminApi\AbstractNode::put
      */
-    public function testUpdateOrCreateUpstream()
+    public function testUpdateOrAddPlugin()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
             ->method('getHttpClient')
             ->will($this->returnValue($this->httpClient));
 
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
         // mock `document`
         $document = $this->createMock(Document::class);
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
 
         // stub `set created at` method from `document` mock
         $document->expects($this->once())
@@ -255,29 +286,61 @@ class UpstreamTest extends TestCase
             ->method('toJson')
             ->will($this->returnValue('{"test":true}'));
 
-        // stub `get` method from `http client` mock
+        // stub `put` method from `http client` mock
         $this->httpClient->expects($this->once())
             ->method('put')
             ->with(
-                $this->equalTo('/upstreams/'),
+                $this->equalTo('/apis/test-api/plugins/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateOrCreateUpstream($document);
+        $node->updateOrAddPlugin('test-api', $document);
     }
 
     /**
-     * test delete upstream
+     * test delete plugin
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Upstream::deleteUpstream
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::deletePlugin
      * @covers \Unikorp\KongAdminApi\AbstractNode::delete
      */
-    public function testDeleteUpstream()
+    public function testDeletePlugin()
+    {
+        // stub `get http client` method from `client` mock
+        $this->client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($this->httpClient));
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // stub `delete` method from `http client` mock
+        $this->httpClient->expects($this->once())
+            ->method('delete')
+            ->with(
+                $this->equalTo('/apis/test-api/plugins/id-plugin'),
+                $this->equalTo(['Content-Type' => 'application/json']),
+                $this->equalTo('[]')
+            )
+            ->will($this->returnValue($response));
+
+        $node = new Node($this->client);
+        $node->deletePlugin('test-api', 'id-plugin');
+    }
+
+    /**
+     * test retrieve enabled plugin
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::retrieveEnabledPlugin
+     * @covers \Unikorp\KongAdminApi\AbstractNode::get
+     */
+    public function testRetrieveEnabledPlugin()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -289,15 +352,45 @@ class UpstreamTest extends TestCase
 
         // stub `get` method from `http client` mock
         $this->httpClient->expects($this->once())
-            ->method('delete')
+            ->method('get')
             ->with(
-                $this->equalTo('/upstreams/test-upstream'),
-                $this->equalTo(['Content-Type' => 'application/json']),
-                $this->equalTo('[]')
+                $this->equalTo('/plugins/enabled?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->deleteUpstream('test-upstream');
+        $node->retrieveEnabledPlugin();
+    }
+
+    /**
+     * test retrieve plugin schema
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Node\PluginNode::retrievePluginSchema
+     * @covers \Unikorp\KongAdminApi\AbstractNode::get
+     */
+    public function testRetrievePluginSchema()
+    {
+        // stub `get http client` method from `client` mock
+        $this->client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($this->httpClient));
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // stub `get` method from `http client` mock
+        $this->httpClient->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/plugins/schema/test-plugin?'),
+                $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
+            )
+            ->will($this->returnValue($response));
+
+        $node = new Node($this->client);
+        $node->retrievePluginSchema('test-plugin');
     }
 }

--- a/tests/Unit/Node/SniNodeTest.php
+++ b/tests/Unit/Node/SniNodeTest.php
@@ -11,16 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\TargetDocument as Document;
-use Unikorp\KongAdminApi\Node\Target as Node;
+use Unikorp\KongAdminApi\Document\SniDocument as Document;
+use Unikorp\KongAdminApi\Node\SniNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * target test
+ * sni node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class TargetTest extends TestCase
+class SniNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +83,14 @@ class TargetTest extends TestCase
     }
 
     /**
-     * test add target
+     * test add sni
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::addTarget
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::addSni
      * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testAddTarget()
+    public function testAddSni()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -112,25 +112,25 @@ class TargetTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('/upstreams/test-upstream/targets'),
+                $this->equalTo('/snis/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->addTarget('test-upstream', $document);
+        $node->addSni($document);
     }
 
     /**
-     * test list targets
+     * test retrieve sni
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::listTargets
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::retrieveSni
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListTargets()
+    public function testRetrieveSni()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -144,24 +144,24 @@ class TargetTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/upstreams/test-upstream/targets?'),
+                $this->equalTo('/snis/test-sni?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listTargets('test-upstream');
+        $node->retrieveSni('test-sni');
     }
 
     /**
-     * test list active targets
+     * test list snis
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::listActiveTargets
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::listSnis
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListActiveTargets()
+    public function testListSnis()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -175,24 +175,109 @@ class TargetTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/upstreams/test-upstream/targets/active?'),
+                $this->equalTo('/snis/?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listActiveTargets('test-upstream');
+        $node->listSnis();
     }
 
     /**
-     * test delete target
+     * test update sni
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Target::deleteTarget
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::updateSni
+     * @covers \Unikorp\KongAdminApi\AbstractNode::patch
+     */
+    public function testUpdateSni()
+    {
+        // stub `get http client` method from `client` mock
+        $this->client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($this->httpClient));
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // mock `document`
+        $document = $this->createMock(Document::class);
+
+        // stub `to json` method from `document` mock
+        $document->expects($this->once())
+            ->method('toJson')
+            ->will($this->returnValue('{"test":true}'));
+
+        // stub `get` method from `http client` mock
+        $this->httpClient->expects($this->once())
+            ->method('patch')
+            ->with(
+                $this->equalTo('/snis/test-sni'),
+                $this->equalTo(['Content-Type' => 'application/json']),
+                $this->equalTo('{"test":true}')
+            )
+            ->will($this->returnValue($response));
+
+        $node = new Node($this->client);
+        $node->updateSni('test-sni', $document);
+    }
+
+    /**
+     * test update or create sni
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::updateOrCreateSni
+     * @covers \Unikorp\KongAdminApi\AbstractNode::put
+     */
+    public function testUpdateOrCreateSni()
+    {
+        // stub `get http client` method from `client` mock
+        $this->client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($this->httpClient));
+
+        // mock `response`
+        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
+
+        // mock `document`
+        $document = $this->createMock(Document::class);
+
+        // stub `set created at` method from `document` mock
+        $document->expects($this->once())
+            ->method('setCreatedAt')
+            ->with($this->isType('int'));
+
+        // stub `to json` method from `document` mock
+        $document->expects($this->once())
+            ->method('toJson')
+            ->will($this->returnValue('{"test":true}'));
+
+        // stub `get` method from `http client` mock
+        $this->httpClient->expects($this->once())
+            ->method('put')
+            ->with(
+                $this->equalTo('/snis/'),
+                $this->equalTo(['Content-Type' => 'application/json']),
+                $this->equalTo('{"test":true}')
+            )
+            ->will($this->returnValue($response));
+
+        $node = new Node($this->client);
+        $node->updateOrCreateSni($document);
+    }
+
+    /**
+     * test delete sni
+     *
+     * @return void
+     *
+     * @covers \Unikorp\KongAdminApi\Node\SniNode::deleteSni
      * @covers \Unikorp\KongAdminApi\AbstractNode::delete
      */
-    public function testDeleteTarget()
+    public function testDeleteSni()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -206,13 +291,13 @@ class TargetTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/upstreams/test-upstream/targets/test-target'),
+                $this->equalTo('/snis/test-sni'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('[]')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->deleteTarget('test-upstream', 'test-target');
+        $node->deleteSni('test-sni');
     }
 }

--- a/tests/Unit/Node/TargetNodeTest.php
+++ b/tests/Unit/Node/TargetNodeTest.php
@@ -11,16 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\SniDocument as Document;
-use Unikorp\KongAdminApi\Node\Sni as Node;
+use Unikorp\KongAdminApi\Document\TargetDocument as Document;
+use Unikorp\KongAdminApi\Node\TargetNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * sni test
+ * target node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class SniTest extends TestCase
+class TargetNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +83,14 @@ class SniTest extends TestCase
     }
 
     /**
-     * test add sni
+     * test add target
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::addSni
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::addTarget
      * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testAddSni()
+    public function testAddTarget()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -112,25 +112,25 @@ class SniTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('/snis/'),
+                $this->equalTo('/upstreams/test-upstream/targets'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->addSni($document);
+        $node->addTarget('test-upstream', $document);
     }
 
     /**
-     * test retrieve sni
+     * test list targets
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::retrieveSni
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::listTargets
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrieveSni()
+    public function testListTargets()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -144,24 +144,24 @@ class SniTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/snis/test-sni?'),
+                $this->equalTo('/upstreams/test-upstream/targets?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveSni('test-sni');
+        $node->listTargets('test-upstream');
     }
 
     /**
-     * test list snis
+     * test list active targets
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::listSnis
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::listActiveTargets
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListSnis()
+    public function testListActiveTargets()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -175,109 +175,24 @@ class SniTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/snis/?'),
+                $this->equalTo('/upstreams/test-upstream/targets/active?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listSnis();
+        $node->listActiveTargets('test-upstream');
     }
 
     /**
-     * test update sni
+     * test delete target
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::updateSni
-     * @covers \Unikorp\KongAdminApi\AbstractNode::patch
-     */
-    public function testUpdateSni()
-    {
-        // stub `get http client` method from `client` mock
-        $this->client->expects($this->once())
-            ->method('getHttpClient')
-            ->will($this->returnValue($this->httpClient));
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
-        // mock `document`
-        $document = $this->createMock(Document::class);
-
-        // stub `to json` method from `document` mock
-        $document->expects($this->once())
-            ->method('toJson')
-            ->will($this->returnValue('{"test":true}'));
-
-        // stub `get` method from `http client` mock
-        $this->httpClient->expects($this->once())
-            ->method('patch')
-            ->with(
-                $this->equalTo('/snis/test-sni'),
-                $this->equalTo(['Content-Type' => 'application/json']),
-                $this->equalTo('{"test":true}')
-            )
-            ->will($this->returnValue($response));
-
-        $node = new Node($this->client);
-        $node->updateSni('test-sni', $document);
-    }
-
-    /**
-     * test update or create sni
-     *
-     * @return void
-     *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::updateOrCreateSni
-     * @covers \Unikorp\KongAdminApi\AbstractNode::put
-     */
-    public function testUpdateOrCreateSni()
-    {
-        // stub `get http client` method from `client` mock
-        $this->client->expects($this->once())
-            ->method('getHttpClient')
-            ->will($this->returnValue($this->httpClient));
-
-        // mock `response`
-        $response = $this->createMock('\GuzzleHttp\Psr7\Response');
-
-        // mock `document`
-        $document = $this->createMock(Document::class);
-
-        // stub `set created at` method from `document` mock
-        $document->expects($this->once())
-            ->method('setCreatedAt')
-            ->with($this->isType('int'));
-
-        // stub `to json` method from `document` mock
-        $document->expects($this->once())
-            ->method('toJson')
-            ->will($this->returnValue('{"test":true}'));
-
-        // stub `get` method from `http client` mock
-        $this->httpClient->expects($this->once())
-            ->method('put')
-            ->with(
-                $this->equalTo('/snis/'),
-                $this->equalTo(['Content-Type' => 'application/json']),
-                $this->equalTo('{"test":true}')
-            )
-            ->will($this->returnValue($response));
-
-        $node = new Node($this->client);
-        $node->updateOrCreateSni($document);
-    }
-
-    /**
-     * test delete sni
-     *
-     * @return void
-     *
-     * @covers \Unikorp\KongAdminApi\Node\Sni::deleteSni
+     * @covers \Unikorp\KongAdminApi\Node\TargetNode::deleteTarget
      * @covers \Unikorp\KongAdminApi\AbstractNode::delete
      */
-    public function testDeleteSni()
+    public function testDeleteTarget()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -291,13 +206,13 @@ class SniTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/snis/test-sni'),
+                $this->equalTo('/upstreams/test-upstream/targets/test-target'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('[]')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->deleteSni('test-sni');
+        $node->deleteTarget('test-upstream', 'test-target');
     }
 }

--- a/tests/Unit/Node/UpstreamNodeTest.php
+++ b/tests/Unit/Node/UpstreamNodeTest.php
@@ -11,16 +11,16 @@
 
 namespace Unikorp\KongAdminApi\Tests\Unit\Node;
 
-use Unikorp\KongAdminApi\Document\CertificateDocument as Document;
-use Unikorp\KongAdminApi\Node\Certificate as Node;
+use Unikorp\KongAdminApi\Document\UpstreamDocument as Document;
+use Unikorp\KongAdminApi\Node\UpstreamNode as Node;
 use PHPUnit\Framework\TestCase;
 
 /**
- * certificate test
+ * upstream node test
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
-class CertificateTest extends TestCase
+class UpstreamNodeTest extends TestCase
 {
     /**
      * client
@@ -83,14 +83,14 @@ class CertificateTest extends TestCase
     }
 
     /**
-     * test add certificate
+     * test add upstream
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::addCertificate
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::addUpstream
      * @covers \Unikorp\KongAdminApi\AbstractNode::post
      */
-    public function testAddCertificate()
+    public function testAddUpstream()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -112,25 +112,25 @@ class CertificateTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('/certificates/'),
+                $this->equalTo('/upstreams/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->addCertificate($document);
+        $node->addUpstream($document);
     }
 
     /**
-     * test retrieve certificate
+     * test retrieve upstream
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::retrieveCertificate
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::retrieveUpstream
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testRetrieveCertificate()
+    public function testRetrieveUpstream()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -144,24 +144,24 @@ class CertificateTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/certificates/test-certificate?'),
+                $this->equalTo('/upstreams/test-upstream?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->retrieveCertificate('test-certificate');
+        $node->retrieveUpstream('test-upstream');
     }
 
     /**
-     * test list certificates
+     * test list upstreams
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::listCertificates
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::listUpstreams
      * @covers \Unikorp\KongAdminApi\AbstractNode::get
      */
-    public function testListCertificates()
+    public function testListUpstreams()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -175,24 +175,24 @@ class CertificateTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('get')
             ->with(
-                $this->equalTo('/certificates/?'),
+                $this->equalTo('/upstreams/?'),
                 $this->equalTo(['Content-Type' => 'application/x-www-form-urlencoded'])
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->listCertificates();
+        $node->listUpstreams();
     }
 
     /**
-     * test update certificate
+     * test update upstream
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::updateCertificate
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::updateUpstream
      * @covers \Unikorp\KongAdminApi\AbstractNode::patch
      */
-    public function testUpdateCertificate()
+    public function testUpdateUpstream()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -214,25 +214,25 @@ class CertificateTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('patch')
             ->with(
-                $this->equalTo('/certificates/test-certificate'),
+                $this->equalTo('/upstreams/test-upstream'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateCertificate('test-certificate', $document);
+        $node->updateUpstream('test-upstream', $document);
     }
 
     /**
-     * test update or create certificate
+     * test update or create upstream
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::updateOrCreateCertificate
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::updateOrCreateUpstream
      * @covers \Unikorp\KongAdminApi\AbstractNode::put
      */
-    public function testUpdateOrCreateCertificate()
+    public function testUpdateOrCreateUpstream()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -259,25 +259,25 @@ class CertificateTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('put')
             ->with(
-                $this->equalTo('/certificates/'),
+                $this->equalTo('/upstreams/'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('{"test":true}')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->updateOrCreateCertificate($document);
+        $node->updateOrCreateUpstream($document);
     }
 
     /**
-     * test delete certificate
+     * test delete upstream
      *
      * @return void
      *
-     * @covers \Unikorp\KongAdminApi\Node\Certificate::deleteCertificate
+     * @covers \Unikorp\KongAdminApi\Node\UpstreamNode::deleteUpstream
      * @covers \Unikorp\KongAdminApi\AbstractNode::delete
      */
-    public function testDeleteCertificate()
+    public function testDeleteUpstream()
     {
         // stub `get http client` method from `client` mock
         $this->client->expects($this->once())
@@ -291,13 +291,13 @@ class CertificateTest extends TestCase
         $this->httpClient->expects($this->once())
             ->method('delete')
             ->with(
-                $this->equalTo('/certificates/test-certificate'),
+                $this->equalTo('/upstreams/test-upstream'),
                 $this->equalTo(['Content-Type' => 'application/json']),
                 $this->equalTo('[]')
             )
             ->will($this->returnValue($response));
 
         $node = new Node($this->client);
-        $node->deleteCertificate('test-certificate');
+        $node->deleteUpstream('test-upstream');
     }
 }


### PR DESCRIPTION
# Description

Rename nodes

# Breaking Changes

- `Unikorp\KongAdminApi\Node\Api` -> `Unikorp\KongAdminApi\Node\ApiNode`
- `Unikorp\KongAdminApi\Node\Certificate` -> `Unikorp\KongAdminApi\Node\CertificateNode`
- `Unikorp\KongAdminApi\Node\Cluster` -> `Unikorp\KongAdminApi\Node\ClusterNode`
- `Unikorp\KongAdminApi\Node\Consumer` -> `Unikorp\KongAdminApi\Node\ConsumerNode`
- `Unikorp\KongAdminApi\Node\Information` -> `Unikorp\KongAdminApi\Node\InformationNode`
- `Unikorp\KongAdminApi\Node\Plugin` -> `Unikorp\KongAdminApi\Node\PluginNode`
- `Unikorp\KongAdminApi\Node\Sni` -> `Unikorp\KongAdminApi\Node\SniNode`
- `Unikorp\KongAdminApi\Node\Target` -> `Unikorp\KongAdminApi\Node\TargetNode`
- `Unikorp\KongAdminApi\Node\Upstream` -> `Unikorp\KongAdminApi\Node\UpstreamNode`

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | no
| BC breaks ?    | yes
| Deprecations ? | no
| Tests pass ?   | no
| Fixed tickets  | ~
| License        | MIT
