### PR TITLE
chore(phpdoc): add missing param

### DIFF
--- a/src/AbstractNode.php
+++ b/src/AbstractNode.php
@@ -54,6 +54,7 @@ abstract class AbstractNode implements NodeInterface
      * get
      *
      * @param string $endpoint
+     * @param DocumentInterface $document
      *
      * @return \Psr\Http\Message\ResponseInterface
      */


### PR DESCRIPTION
# Description

add missing phpdoc param for `Unikorp\KongAdminApi\AbstractNode::get`

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | no
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | ~
| License        | MIT
